### PR TITLE
fix(claude): make the npm hook the single gate for npm commands

### DIFF
--- a/dot-claude/hooks/allow-readonly-npm.sh
+++ b/dot-claude/hooks/allow-readonly-npm.sh
@@ -7,7 +7,7 @@
 #
 # To allow a new command verbatim, add a line to ALLOWED below. Each entry
 # is a human-readable template. Placeholders in <angle-brackets> are
-# substituted with the regex fragments defined above (<pkg>, <field>);
+# substituted with the regex fragments defined above (<pkg>, <field>, <json>);
 # the rest is matched literally as part of an anchored regex.
 #
 # Rules for any line you add to ALLOWED:
@@ -35,19 +35,27 @@ PKG='(@[a-z0-9][a-z0-9._-]*/)?[a-z0-9][a-z0-9._-]*(@[a-zA-Z0-9._^~-]+)?'
 # instead.
 FIELD='[a-zA-Z0-9][a-zA-Z0-9._-]*'
 
+# Optional ` --json` output flag. Regex-only — never appears literally in an
+# ALLOWED template, so the parens/`?` are matching syntax, not part of the
+# approved command (which contains the harmless literal `--json`).
+JSON='( --json)?'
+
 ALLOWED=(
-  'npm view <pkg>'
-  'npm view <pkg> <field>'
-  'npm info <pkg>'
-  'npm info <pkg> <field>'
-  'npm show <pkg>'
-  'npm show <pkg> <field>'
+  'npm view <pkg><json>'
+  'npm view <pkg> <field><json>'
+  'npm info <pkg><json>'
+  'npm info <pkg> <field><json>'
+  'npm show <pkg><json>'
+  'npm show <pkg> <field><json>'
+  'npm --version'
+  'npm -v'
 )
 
 substitute() {
   local s=$1
   s=${s//<pkg>/${PKG}}
   s=${s//<field>/${FIELD}}
+  s=${s//<json>/${JSON}}
   printf '%s' "$s"
 }
 
@@ -66,11 +74,14 @@ CMD=$(jq -r '.tool_input.command // empty' <<<"$INPUT" 2>/dev/null) || exit 0
 
 # Only act on commands whose first token is literally `npm`. Anything else
 # (pnpm, yarn, bun, npx, anything containing $0/$@/$!, …) gets no decision so
-# static rules in settings.json decide. Empirically (tested 2026-05-12) the
-# `if: "Bash(npm *)"` clause on this hook is unreliable — it fires the hook
-# for many commands that contain no `npm` substring at all (e.g. `echo $0`,
-# `echo $@`, multi-line backgrounded commands with `$!`). This in-script
-# guard is the real gate; do not remove it.
+# static rules in settings.json / bypassPermissions decide. This hook is
+# wired with `if: "Bash(*npm*)"` (substring match), so it's only invoked for
+# commands that contain "npm" — not every Bash call. The substring form (not
+# the old `npm *` prefix) is deliberate: it also fires for ` npm install`
+# (leading space) and `FOO=1 npm install`, which a prefix glob would miss and
+# thus let auto-run under bypassPermissions. Over-firing on harmless matches
+# (pnpm, an `echo "npm"`, …) is fine — this in-script guard abstains on them.
+# This guard is the real gate; do not remove it.
 TRIMMED="${CMD#"${CMD%%[![:space:]]*}"}"
 case "$TRIMMED" in
   npm|npm\ *) ;;
@@ -88,7 +99,7 @@ done
 LIST=$(printf '  • %s\n' "${ALLOWED[@]}")
 emit deny "This npm invocation is not in the allow-list. Allowed shapes (must match the entire command):
 ${LIST}
-where <pkg> is a lowercase package name with an optional @scope/ prefix and optional @version, containing only [a-z0-9._-] in the name and [a-zA-Z0-9._^~-] in the version. No flags, no extra args, no shell metacharacters.
+where <pkg> is a lowercase package name with an optional @scope/ prefix and optional @version (containing only [a-z0-9._-] in the name and [a-zA-Z0-9._^~-] in the version), <field> is a dotted field path like version / dist-tags.latest, and <json> is an optional trailing --json flag. One package per call (npm reads only the first); for several, query each separately. No other flags, no extra args, no shell metacharacters.
 
 If you genuinely need a different invocation, ask the user to add it to ~/.claude/hooks/allow-readonly-npm.sh — do not try to work around this hook."
 exit 0

--- a/dot-claude/hooks/tests/allow-readonly-npm.test.sh
+++ b/dot-claude/hooks/tests/allow-readonly-npm.test.sh
@@ -52,6 +52,11 @@ assert_allows 'npm view react@^18'
 assert_allows 'npm view react@~18.2'
 assert_allows 'npm view react@18.0.0-rc.1'
 assert_allows 'npm view @types/node@20.10.0'
+assert_allows 'npm view react --json'
+assert_allows 'npm view react version --json'
+assert_allows 'npm info @types/node dist-tags.latest --json'
+assert_allows 'npm --version'
+assert_allows 'npm -v'
 
 # --- subcommand must be exactly one of view|info|show ----------------------
 assert_denies 'npm v react'
@@ -65,8 +70,6 @@ assert_denies 'npm why react'
 assert_denies 'npm outdated'
 assert_denies 'npm ping'
 assert_denies 'npm help install'
-assert_denies 'npm --version'
-assert_denies 'npm -v'
 assert_denies 'npm config get registry'
 assert_denies 'npm publish'
 assert_denies 'npm run build'
@@ -74,12 +77,12 @@ assert_denies 'npm exec left-pad'
 assert_denies 'npm uninstall react'
 assert_denies 'npm docs left-pad'
 
-# --- shape constraints: exactly one package arg, nothing else --------------
+# --- shape constraints: one package arg, optional field, nothing else ------
 assert_denies 'npm view'
-assert_denies 'npm view react version'
+assert_allows 'npm view react version'
 assert_denies 'npm view react foo bar'
-assert_denies 'npm view --json react'
-assert_denies 'npm view react --json'
+assert_denies 'npm view --json react'   # --json must be trailing
+assert_denies 'npm view react --json --json'
 assert_denies 'npm view  react'   # double space
 assert_denies ' npm view react'   # leading space
 assert_denies 'npm view react '   # trailing space

--- a/dot-claude/settings.json
+++ b/dot-claude/settings.json
@@ -70,9 +70,6 @@
       "Bash(which *)",
       "Bash(xargs cat*)",
       "Bash(node --version*)",
-      "Bash(npm --version*)",
-      "Bash(npm info *)",
-      "Bash(npm view *)",
       "Bash(pnpm --version*)",
       "Bash(bun --version*)",
       "Bash(pnpm list *)",
@@ -115,7 +112,6 @@
       "Bash(wget * | bash *)",
       "Bash(wget * | sh *)",
       "Bash(wget * | zsh *)",
-      "Bash(npm *)",
       "Bash(yarn *)"
     ],
     "ask": [
@@ -152,7 +148,7 @@
           {
             "type": "command",
             "command": "~/.claude/hooks/allow-readonly-npm.sh",
-            "if": "Bash(npm *)"
+            "if": "Bash(*npm*)"
           }
         ]
       },


### PR DESCRIPTION
The npm read-only allow-list was split between static rules in settings.json and the hook, and the hook's `npm *` prefix matcher let env-prefixed or leading-space invocations slip past shape validation under bypassPermissions.

The hook is now the single gate: substring matching fires it on any command containing npm, an in-script guard abstains on non-npm commands (pnpm, echo, ...), and the static npm rules are gone. The allow-list gains `--json` output and `npm --version`. Stale test assertions are brought in line with the hook.
