### PR TITLE
fix(claude): fail closed on unknown gh flags and tab-separated npm

### DIFF
--- a/dot-claude/hooks/allow-draft-pr.sh
+++ b/dot-claude/hooks/allow-draft-pr.sh
@@ -22,14 +22,20 @@
 # a parent whose owner cannot be resolved abstains rather than falling back
 # to the fork's own owner.
 #
-# Long-form flags only: ANY short flag abstains. pflag accepts spellings this
-# scanner does not model (-Rx, -R=x, combined -fR clusters), and a misparsed
-# target repo must never fall back to cwd resolution while gh sends the PR
-# elsewhere. Same reasoning for --repo with a missing/empty value.
+# Only flags the scanner fully models are accepted; anything else abstains.
+# Short flags: pflag accepts spellings this scanner does not model (-Rx,
+# -R=x, combined -fR clusters), and a misparsed target repo must never fall
+# back to cwd resolution while gh sends the PR elsewhere. Same reasoning for
+# --repo with a missing/empty value. Unknown long flags: a future gh
+# value-taking flag would swallow the next word, so `--newflag --draft`
+# would read as draft here while gh creates a non-draft PR — vocabulary
+# drift must fail toward prompting. Ditto `--draft=false` after `--draft`
+# (pflag is last-wins). --web and --editor are deliberately not allow-listed:
+# --web hands draft-ness to the browser, --editor hangs in a headless shell.
 #
 # Flag scan skips the value after each value-taking flag, so `--title
 # --draft` (a NON-draft PR titled "--draft") is not mistaken for a draft.
-# The value-flag list mirrors `gh pr create --help` and must be kept in sync.
+# Both flag lists mirror `gh pr create --help` and must be kept in sync.
 # Threat model is an inattentive agent, not an adversary (same stance as
 # block-dangerous-git.sh).
 
@@ -96,7 +102,7 @@ while [ "$i" -lt "$n" ]; do
     --assignee|--base|--body|--body-file|--head|--label|\
     --milestone|--project|--reviewer|--template|--title|--recover)
       i=$((i + 1)) ;;
-    --*) ;;
+    --fill|--fill-first|--fill-verbose|--dry-run|--no-maintainer-edit) ;;
     -*) exit 0 ;;
   esac
   i=$((i + 1))

--- a/dot-claude/hooks/allow-readonly-npm.sh
+++ b/dot-claude/hooks/allow-readonly-npm.sh
@@ -89,7 +89,7 @@ CMD=$(jq -r '.tool_input.command // empty' <<<"$INPUT" 2>/dev/null) || exit 0
 # This guard is the real gate; do not remove it.
 TRIMMED="${CMD#"${CMD%%[![:space:]]*}"}"
 case "$TRIMMED" in
-  npm|npm\ *) ;;
+  npm|npm[[:space:]]*) ;;
   *) exit 0 ;;
 esac
 

--- a/dot-claude/hooks/tests/allow-draft-pr.test.sh
+++ b/dot-claude/hooks/tests/allow-draft-pr.test.sh
@@ -57,11 +57,21 @@ assert_allows "gh pr create --repo 47ng/nuqs --title \"feat: add thing\" --draft
 line two with \`backticks\` and \$afe chars inside single quotes'"
 assert_allows "gh pr create --draft --repo franky47/dotfiles --base main --head feat/x --title 'feat: z' --body-file /tmp/b.md"
 assert_allows "gh pr create --draft --repo='franky47/some-repo' --fill"
+assert_allows 'gh pr create --draft --repo franky47/dotfiles --fill-verbose'
+
+# long flags outside the known-boolean allow-list abstain: gh vocabulary
+# drift must fail toward prompting, --web hands draft-ness to the browser,
+# --editor hangs in a headless shell
+assert_no_decision 'gh pr create --draft --repo franky47/x --web'
+assert_no_decision 'gh pr create --draft --repo franky47/x --editor'
+assert_no_decision 'gh pr create --draft --repo franky47/x --some-future-flag'
 
 # --- missing/subverted --draft → abstain ------------------------------------
 assert_no_decision "gh pr create --repo franky47/dotfiles --title 'feat: x' --body-file /tmp/b.md"
 assert_no_decision 'gh pr create --draft=false --repo franky47/dotfiles --fill'
 assert_no_decision 'gh pr create --draft=true --repo franky47/dotfiles --fill'
+# pflag booleans are last-wins: gh would create a NON-draft PR here
+assert_no_decision 'gh pr create --draft --draft=false --repo franky47/dotfiles --fill'
 # --draft here is the VALUE of --title, not a flag: the PR would not be draft
 assert_no_decision 'gh pr create --title --draft --repo franky47/dotfiles --fill'
 assert_no_decision 'gh pr create -t --draft --repo franky47/dotfiles --fill'

--- a/dot-claude/hooks/tests/allow-readonly-npm.test.sh
+++ b/dot-claude/hooks/tests/allow-readonly-npm.test.sh
@@ -119,6 +119,7 @@ assert_denies 'npm view react > /tmp/x'
 assert_denies 'npm view react >> /tmp/x'
 assert_denies $'npm view react\nrm -rf /tmp/x'
 assert_denies $'npm view react\trm'        # tab between args
+assert_denies $'npm\tview react'           # tab right after npm: still first-token npm
 
 # --- argument-injection via post-hook shell expansion ----------------------
 assert_denies 'npm view *'


### PR DESCRIPTION
Follow-up to #3, applying the post-CI review flight findings that landed after it merged.

The draft-PR hook's wildcard for unknown long flags was fail-open. That let `--draft --draft=false` auto-approve while gh (last-wins) creates a non-draft PR, and it meant any future value-taking gh flag could swallow `--draft` the same way after a routine gh upgrade, silently. Boolean flags are now allow-listed and everything unknown abstains. `--web` and `--editor` are deliberately left out: `--web` moves the draft decision to the browser, `--editor` hangs in a headless shell.

The npm hook's guard only recognized `npm` followed by a space, so a tab-separated `npm` command abstained and auto-ran under bypassPermissions. The guard now accepts any whitespace, making the header's first-token claim true.

Both closures are pinned by tests written red-first.
