### PR TITLE
fix(claude): abstain on trailing value-flags in draft-PR hook

### DIFF
--- a/dot-claude/hooks/allow-draft-pr.sh
+++ b/dot-claude/hooks/allow-draft-pr.sh
@@ -101,7 +101,7 @@ while [ "$i" -lt "$n" ]; do
     --repo=*) repo=${w#--repo=}; [ -n "$repo" ] || exit 0 ;;
     --assignee|--base|--body|--body-file|--head|--label|\
     --milestone|--project|--reviewer|--template|--title|--recover)
-      i=$((i + 1)) ;;
+      i=$((i + 1)); [ "$i" -lt "$n" ] || exit 0 ;;
     --fill|--fill-first|--fill-verbose|--dry-run|--no-maintainer-edit) ;;
     -*) exit 0 ;;
   esac

--- a/dot-claude/hooks/tests/allow-draft-pr.test.sh
+++ b/dot-claude/hooks/tests/allow-draft-pr.test.sh
@@ -66,6 +66,11 @@ assert_no_decision 'gh pr create --draft --repo franky47/x --web'
 assert_no_decision 'gh pr create --draft --repo franky47/x --editor'
 assert_no_decision 'gh pr create --draft --repo franky47/x --some-future-flag'
 
+# a trailing value-taking flag with no value is not a fully-modeled command;
+# gh happens to reject it at parse time, but the hook must not vouch for it
+assert_no_decision 'gh pr create --draft --repo franky47/x --title'
+assert_no_decision 'gh pr create --draft --repo franky47/x --body-file'
+
 # --- missing/subverted --draft → abstain ------------------------------------
 assert_no_decision "gh pr create --repo franky47/dotfiles --title 'feat: x' --body-file /tmp/b.md"
 assert_no_decision 'gh pr create --draft=false --repo franky47/dotfiles --fill'


### PR DESCRIPTION
Final follow-up from the adversarial probe of #4 (100 cases, no exploitable false allow found).

One contract deviation remained: a value-taking flag with no value at the end of the command (`gh pr create --draft --repo franky47/x --title`) was allowed. It is inert today only because gh rejects the missing argument at parse time, so the hook was borrowing safety from gh's parser instead of owning it. The skip arm now abstains when no value exists, matching the empty-value guards `--repo` already has.

The probe's two other notes were verified safe and left as is: trailing newlines stripped by command substitution cannot change what executes, and the npm guard denying single-token oddities like `npm\vx` fails in the safe direction.
