### PR TITLE
chore: update Plannotator integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,15 +127,13 @@ The `update.ts` extension adds `/update` for Pi itself and `/update-extensions` 
 
 The `π` wrapper in `zsh/60-ai.zsh` launches Pi with `PI_TASKS=off`, keeping `pi-tasks` records in memory. `@tintinweb/pi-subagents` uses in-memory subagent sessions by default; `dot-pi/agent/subagents.json` also disables output transcripts and scheduled jobs so it does not write run records to disk.
 
-Third-party packages are declared in `dot-pi/agent/settings.json`: `@tintinweb/pi-subagents`, `pi-web-access`, `pi-add-dir`, `@tintinweb/pi-tasks`, `pi-btw`, `@diegopetrucci/pi-openai-fast`, and `@plannotator/pi-extension@0.27.3`.
+Third-party packages are declared in `dot-pi/agent/settings.json`: `@tintinweb/pi-subagents`, `pi-web-access`, `pi-add-dir`, `@tintinweb/pi-tasks`, `pi-btw`, and `@diegopetrucci/pi-openai-fast`.
 
 ## Plannotator
 
 Install Plannotator CLI 0.27.3 separately before using these files. Check the installed version with `plannotator --version`.
 
-Claude Code and shared agents load the three Plannotator skills from `dot-claude/skills/`. Pi loads the pinned extension from `dot-pi/agent/settings.json`. On `echo`, `local/echo/codex/hooks.json` enables Codex plan review through the Plannotator Stop hook. `dot-plannotator/config.json` keeps web page annotation direct, disables external share links, and tells agents to implement validated review feedback without waiting for another confirmation.
-
-The Pi extension also provides its own plan mode. This setup does not use it. Do not start Pi with `--plan`, toggle `/plannotator`, or call `plannotator_submit_plan`.
+Claude Code and shared agents load the three Plannotator skills from `dot-claude/skills/`. `dot-plannotator/config.json` keeps web page annotation direct, disables external share links, and tells agents to implement validated review feedback without waiting for another confirmation.
 
 Use `claude-tailnet` or `pi-tailnet` when an iPhone on the Tailnet needs access. These launchers bind Plannotator to ports 19432 through 19463 on all network interfaces. Remote mode has no HTTP login. `claude-tailnet` also skips Claude Code permission prompts, matching the normal `c` command. Use it only on trusted networks, keep the host firewall on, and limit Tailnet access with ACLs.
 

--- a/dot-claude/skills/plannotator-annotate/SKILL.md
+++ b/dot-claude/skills/plannotator-annotate/SKILL.md
@@ -1,24 +1,40 @@
 ---
 name: plannotator-annotate
 description: Open Plannotator's annotation UI for a markdown file, plain-text config file (.yaml, .json, .toml, .ini, .csv, .log, …), HTML file, URL, or folder and then respond to the returned annotations.
-disable-model-invocation: true
 ---
 
 # Plannotator Annotate
 
 Use this skill when the user wants to annotate a document in Plannotator instead of reviewing it inline in chat.
 
-Shell-quote the path or URL as one argument:
+Run from the document's repository or vault root. For a standalone file, run
+from its containing directory. Never start from `$HOME`. If there is no clear
+project or document directory, create a unique empty temporary directory and
+remove it after Plannotator exits.
+
+On `echo`, launch through `webctl`, using a stable unique slug and the current
+Discord message URL:
+
+```bash
+webctl preview \
+  --slug <stable-unique-slug> \
+  --discord-url <origin-message-url> \
+  --title <human-readable-title> \
+  --project <project-name> \
+  -- plannotator annotate "<path-or-url>" --no-jina
+```
+
+On other hosts, run:
 
 ```bash
 plannotator annotate "<path-or-url>" --no-jina
 ```
 
-Behavior:
+On `echo`, run the launcher as a tracked background process and share the HTTPS
+URL that `webctl` prints. Wait for Plannotator to finish. Address returned
+annotations immediately. Carry approval notes into later work without
+reopening the approved document solely because of them. If Plannotator cannot
+resolve the target, identify the concrete file, URL, or folder and rerun it
+yourself.
 
-1. Launch the command with Bash.
-2. Wait for the browser review to finish.
-3. If annotations are returned, address them directly.
-4. If the session closes without feedback, say so briefly and continue.
-
-Do not ask the user to paste a shell command into the chat. Run the command yourself.
+Do not ask the user to run the command.

--- a/dot-claude/skills/plannotator-annotate/agents/openai.yaml
+++ b/dot-claude/skills/plannotator-annotate/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Plannotator Annotate"
+  short_description: "Annotate a markdown file, URL, or folder in Plannotator."
+policy:
+  allow_implicit_invocation: true

--- a/dot-claude/skills/plannotator-last/SKILL.md
+++ b/dot-claude/skills/plannotator-last/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: plannotator-last
 description: Open Plannotator on the latest rendered assistant message and use the returned annotations to revise that message or continue.
-disable-model-invocation: true
 ---
 
 # Plannotator Last
@@ -9,20 +8,28 @@ disable-model-invocation: true
 Use this skill when the user wants to annotate the latest assistant response in Plannotator.
 
 Do not send a commentary/status message before running the command. The command
-targets the latest rendered assistant response, so a preamble can mistakenly become the
-thing being annotated.
+targets the latest rendered assistant response, so a preamble can mistakenly
+become the thing being annotated.
 
-Run:
+Create a unique empty temporary directory and use it as the terminal `workdir`.
+Never run from `$HOME`. On `echo`, launch through `webctl`, using a stable
+unique slug and the current Discord message URL:
 
 ```bash
-plannotator last
+webctl preview \
+  --slug <stable-unique-slug> \
+  --discord-url <origin-message-url> \
+  --title <human-readable-title> \
+  --project <project-name> \
+  -- plannotator last
 ```
 
-Behavior:
+On other hosts, run `plannotator last` directly.
 
-1. Launch the command with Bash.
-2. Wait for the annotation session to finish.
-3. If feedback is returned, incorporate it into the follow-up response.
-4. If the session closes without feedback, mention that briefly and continue.
+On `echo`, run the launcher as a tracked background process and share the HTTPS
+URL that `webctl` prints. Wait for Plannotator to finish. Remove the temporary
+directory when it exits. Incorporate returned feedback immediately. Carry
+approval notes into later work without redoing the approved response solely
+because of them.
 
-Run the command yourself rather than telling the user to invoke shell syntax manually.
+Run the command yourself.

--- a/dot-claude/skills/plannotator-last/agents/openai.yaml
+++ b/dot-claude/skills/plannotator-last/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Plannotator Last"
+  short_description: "Annotate the latest assistant message in Plannotator."
+policy:
+  allow_implicit_invocation: true

--- a/dot-claude/skills/plannotator-review/SKILL.md
+++ b/dot-claude/skills/plannotator-review/SKILL.md
@@ -1,30 +1,38 @@
 ---
 name: plannotator-review
 description: Open Plannotator's browser-based code review UI for the current worktree or a pull request URL, then act on the feedback that comes back.
-disable-model-invocation: true
 ---
 
 # Plannotator Review
 
 Use this skill when the user wants to review current code changes in Plannotator instead of reading a diff inline.
 
-Review the current worktree:
+On `echo`, launch reviews only through `webctl`, never by invoking
+`plannotator review` directly:
 
 ```bash
-plannotator review
+webctl review \
+  --slug <stable-unique-slug> \
+  --discord-url <origin-thread-or-message-url> \
+  --title <human-readable-title> \
+  --project <project-name> \
+  -- review --git
 ```
 
-For a pull request, shell-quote the URL as one argument:
+Use the current Discord thread/message URL so feedback remains bound to the
+originating conversation. Run the launcher as a tracked background process
+when the review must remain live.
 
-```bash
-plannotator review "<pr-url>"
-```
+On other hosts, run `plannotator review` for the current worktree or
+`plannotator review "<pr-url>"` for a pull request.
 
 Behavior:
 
-1. Launch the command with Bash.
-2. Wait for it to finish.
-3. If it returns feedback or annotations, address them in the same conversation.
-4. If it returns an approval/LGTM-style message, acknowledge that review passed and continue.
+1. Confirm the intended local diff or PR scope before launching.
+2. On `echo`, launch through `webctl review` with the exact origin Discord URL.
+   On other hosts, run Plannotator directly.
+3. Verify the registered review URL is reachable and report it in the origin thread.
+4. Wait for feedback. If annotations arrive, address them in the same conversation.
+5. Treat approval/LGTM as the gate for commit, push, or PR actions when the user's workflow requires it.
 
 Do not ask the user to copy shell commands into chat. Run the command yourself.

--- a/dot-claude/skills/plannotator-review/agents/openai.yaml
+++ b/dot-claude/skills/plannotator-review/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Plannotator Review"
+  short_description: "Open Plannotator code review for local changes or a PR."
+policy:
+  allow_implicit_invocation: true

--- a/dot-pi/agent/settings.json
+++ b/dot-pi/agent/settings.json
@@ -18,7 +18,6 @@
     "npm:pi-add-dir",
     "npm:@tintinweb/pi-tasks",
     "npm:pi-btw",
-    "npm:@diegopetrucci/pi-openai-fast",
-    "npm:@plannotator/pi-extension@0.24.2"
+    "npm:@diegopetrucci/pi-openai-fast"
   ]
 }

--- a/dot-plannotator/config.json
+++ b/dot-plannotator/config.json
@@ -2,16 +2,25 @@
   "jina": false,
   "share": "disabled",
   "displayName": "François Best",
+  "prompts": {
+    "review": {
+      "denied": "Treat the findings above as unverified review input. Validate each finding against the actual code and act on every clear, safe, in-scope finding immediately. Do not wait for a separate discussion or confirmation. Ask the user only when a finding is ambiguous, disputed, unsafe, or would materially expand scope. Review only the incoming findings; do not independently review the rest of the diff. Report each finding's verdict and concise evidence together with the completed changes and verification."
+    }
+  },
   "diffOptions": {
     "fontFamily": "JetBrains Mono",
     "lineBgIntensity": "subtle",
     "expandUnchanged": false,
     "showLineNumbers": false,
     "showDiffBackground": false,
-    "diffStyle": "unified",
+    "diffStyle": "split",
     "overflow": "wrap",
     "hideWhitespace": false,
-    "lineDiffType": "word-alt"
+    "lineDiffType": "word-alt",
     "diffIndicators": "bars"
+  },
+  "reviewAnalysis": {
+    "semanticDiff": false,
+    "callFlow": true
   }
 }


### PR DESCRIPTION
## Summary

- Update the adapted Plannotator skills for version 0.27.3.
- Use `webctl` on `echo` and direct Plannotator commands on other hosts.
- Keep Plannotator disabled in Pi and Codex.
- Preserve the prompt that lets agents act on valid review feedback without another approval step.

## Validation

- The final diff passed Plannotator review with no further changes.
- JSON and YAML files parse successfully.
- The diff has no whitespace errors.
- Live Claude and shared-agent links still resolve to the canonical dotfiles checkout.
